### PR TITLE
Respect gypfile:false in package.json file

### DIFF
--- a/lib/run-script-pkg.js
+++ b/lib/run-script-pkg.js
@@ -29,13 +29,14 @@ const runScriptPkg = async options => {
     event === 'install' &&
     ! pkg.scripts.install &&
     ! pkg.scripts.preinstall &&
+    pkg.gypfile !== false &&
     await isNodeGypPackage(path)
   ) {
     cmd = defaultGypInstallScript
   }
 
   if (!cmd)
-    return Promise.resolve({ code: 0, signal: null })
+    return { code: 0, signal: null }
 
   if (stdio === 'inherit' && banner !== false) {
     // we're dumping to the parent's stdout, so print the banner

--- a/test/run-script-pkg.js
+++ b/test/run-script-pkg.js
@@ -261,6 +261,28 @@ t.test('pkg has no install or preinstall script, but node-gyp files are present'
   ])
 })
 
+t.test('pkg has no install or preinstall script, but gypfile:false', async t => {
+  fakeIsNodeGypPackage = true
+
+  const res = await runScriptPkg({
+    event: 'install',
+    path: 'path',
+    scriptShell: 'sh',
+    env: {
+      environ: 'value',
+    },
+    stdio: 'pipe',
+    pkg: {
+      _id: 'foo@1.2.3',
+      gypfile: false,
+      scripts: {
+      },
+    }
+  })
+
+  t.strictSame(res, { code: 0, signal: null })
+})
+
 t.test('end stdin if present', async t => {
   let stdinEnded = false
   const runScriptPkg = requireInject('../lib/run-script-pkg.js', {


### PR DESCRIPTION
Do not default to loading the node-gyp script if this is set to false
explicitly.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
