### PR TITLE
forward signals to children

### DIFF
--- a/lib/run-script-pkg.js
+++ b/lib/run-script-pkg.js
@@ -2,6 +2,7 @@ const makeSpawnArgs = require('./make-spawn-args.js')
 const promiseSpawn = require('@npmcli/promise-spawn')
 const packageEnvs = require('./package-envs.js')
 const { isNodeGypPackage, defaultGypInstallScript } = require('@npmcli/node-gyp')
+const signalManager = require('./signal-manager')
 
 // you wouldn't like me when I'm angry...
 const bruce = (id, event, cmd) => `\n> ${id ? id + ' ' : ''}${event}\n> ${cmd}\n`
@@ -57,8 +58,11 @@ const runScriptPkg = async options => {
     pkgid: pkg._id,
     path,
   })
+
+  signalManager.add(p.process)
   if (p.stdin)
     p.stdin.end()
+
   return p
 }
 

--- a/lib/run-script-pkg.js
+++ b/lib/run-script-pkg.js
@@ -59,7 +59,9 @@ const runScriptPkg = async options => {
     path,
   })
 
-  signalManager.add(p.process)
+  if (stdio === 'inherit')
+    signalManager.add(p.process)
+
   if (p.stdin)
     p.stdin.end()
 

--- a/lib/run-script-pkg.js
+++ b/lib/run-script-pkg.js
@@ -2,7 +2,7 @@ const makeSpawnArgs = require('./make-spawn-args.js')
 const promiseSpawn = require('@npmcli/promise-spawn')
 const packageEnvs = require('./package-envs.js')
 const { isNodeGypPackage, defaultGypInstallScript } = require('@npmcli/node-gyp')
-const signalManager = require('./signal-manager')
+const signalManager = require('./signal-manager.js')
 
 // you wouldn't like me when I'm angry...
 const bruce = (id, event, cmd) => `\n> ${id ? id + ' ' : ''}${event}\n> ${cmd}\n`

--- a/lib/signal-manager.js
+++ b/lib/signal-manager.js
@@ -1,0 +1,44 @@
+const runningProcs = new Set()
+
+const forwardedSignals = [
+  'SIGINT',
+  'SIGTERM'
+]
+
+function handleSignal (signal) {
+  for (const proc of runningProcs) {
+    proc.kill(signal)
+  }
+}
+
+function setupListeners () {
+  for (const signal of forwardedSignals) {
+    if (!process.listeners(signal).includes(handleSignal)) {
+      process.once(signal, handleSignal)
+    }
+  }
+}
+
+function cleanupListeners () {
+  if (runningProcs.size === 0) {
+    for (const signal of forwardedSignals) {
+      process.removeListener(signal, handleSignal)
+    }
+  }
+}
+
+function add (proc) {
+  runningProcs.add(proc)
+  setupListeners()
+  proc.once('exit', ({ code }) => {
+    process.exitCode = process.exitCode || code
+    runningProcs.delete(proc)
+    cleanupListeners()
+  })
+}
+
+module.exports = {
+  add,
+  handleSignal,
+  forwardedSignals
+}

--- a/lib/signal-manager.js
+++ b/lib/signal-manager.js
@@ -1,35 +1,38 @@
 const runningProcs = new Set()
+let handlersInstalled = false
 
 const forwardedSignals = [
   'SIGINT',
   'SIGTERM'
 ]
 
-function handleSignal (signal) {
+const handleSignal = signal => {
   for (const proc of runningProcs) {
     proc.kill(signal)
   }
 }
 
-function setupListeners () {
+const setupListeners = () => {
   for (const signal of forwardedSignals) {
-    if (!process.listeners(signal).includes(handleSignal)) {
-      process.once(signal, handleSignal)
-    }
+    process.on(signal, handleSignal)
   }
+  handlersInstalled = true
 }
 
-function cleanupListeners () {
+const cleanupListeners = () => {
   if (runningProcs.size === 0) {
     for (const signal of forwardedSignals) {
       process.removeListener(signal, handleSignal)
     }
+    handlersInstalled = false
   }
 }
 
-function add (proc) {
+const add = proc => {
   runningProcs.add(proc)
-  setupListeners()
+  if (!handlersInstalled)
+    setupListeners()
+
   proc.once('exit', ({ code }) => {
     process.exitCode = process.exitCode || code
     runningProcs.delete(proc)

--- a/package-lock.json
+++ b/package-lock.json
@@ -198,9 +198,9 @@
       "integrity": "sha512-BBlx5ZCPCmTrPI2BpynmWpL1hQTRVXSIZ0zI/a9AQsIDXUReA8V/WRJo85TF6Wf0YVBtLibKH3OHrxnbxilthw=="
     },
     "node_modules/@npmcli/promise-spawn": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-1.2.0.tgz",
-      "integrity": "sha512-nFtqjVETliApiRdjbYwKwhlSHx2ZMagyj5b9YbNt0BWeeOVxJd47ZVE2u16vxDHyTOZvk+YLV7INwfAE9a2uow==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-1.3.0.tgz",
+      "integrity": "sha512-jDT6itz19zh/wjW6CxKYHW7e8E6PDRmsAchdzsj0MeAQ8h5IP6fiihGhQgXXxFsSRE5sL25a7P86JuoaG1wGyw==",
       "dependencies": {
         "infer-owner": "^1.0.4"
       }
@@ -6431,9 +6431,9 @@
       "integrity": "sha512-BBlx5ZCPCmTrPI2BpynmWpL1hQTRVXSIZ0zI/a9AQsIDXUReA8V/WRJo85TF6Wf0YVBtLibKH3OHrxnbxilthw=="
     },
     "@npmcli/promise-spawn": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-1.2.0.tgz",
-      "integrity": "sha512-nFtqjVETliApiRdjbYwKwhlSHx2ZMagyj5b9YbNt0BWeeOVxJd47ZVE2u16vxDHyTOZvk+YLV7INwfAE9a2uow==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-1.3.0.tgz",
+      "integrity": "sha512-jDT6itz19zh/wjW6CxKYHW7e8E6PDRmsAchdzsj0MeAQ8h5IP6fiihGhQgXXxFsSRE5sL25a7P86JuoaG1wGyw==",
       "requires": {
         "infer-owner": "^1.0.4"
       }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@npmcli/node-gyp": "^1.0.0",
-    "@npmcli/promise-spawn": "^1.2.0",
+    "@npmcli/promise-spawn": "^1.3.0",
     "infer-owner": "^1.0.4",
     "node-gyp": "^7.1.0",
     "read-package-json-fast": "^1.1.3"

--- a/test/run-script-pkg.js
+++ b/test/run-script-pkg.js
@@ -43,7 +43,7 @@ t.test('pkg has no foo script, but custom cmd provided', t => runScriptPkg({
   pkg: {
     _id: 'foo@1.2.3',
     scripts: {},
-  }
+  },
 }).then(res => t.strictSame(res, ['sh', ['-c', 'bar'], {
   stdioString: false,
   event: 'foo',

--- a/test/signal-manager.js
+++ b/test/signal-manager.js
@@ -1,0 +1,56 @@
+const { EventEmitter } = require('events')
+const { test } = require('tap')
+
+const signalManager = require('../lib/signal-manager')
+
+test('adds only one handler for each signal, removes handlers when children have exited', t => {
+  const procOne = new EventEmitter()
+  const procTwo = new EventEmitter()
+
+  for (const signal of signalManager.forwardedSignals) {
+    t.equal(process.listeners(signal).includes(signalManager.handleSignal), false, 'does not have a listener yet')
+  }
+  signalManager.add(procOne)
+
+  for (const signal of signalManager.forwardedSignals) {
+    t.equal(process.listeners(signal).includes(signalManager.handleSignal), true, 'has a listener for forwarded signals')
+  }
+
+  signalManager.add(procTwo)
+  for (const signal of signalManager.forwardedSignals) {
+    const handlers = process.listeners(signal).filter((fn) => fn === signalManager.handleSignal)
+    t.equal(handlers.length, 1, 'only has one handler')
+  }
+
+  procOne.emit('exit', { code: 0 })
+
+  for (const signal of signalManager.forwardedSignals) {
+    t.equal(process.listeners(signal).includes(signalManager.handleSignal), true, 'did not remove listeners yet')
+  }
+
+  procTwo.emit('exit', { code: 0 })
+
+  for (const signal of signalManager.forwardedSignals) {
+    t.equal(process.listeners(signal).includes(signalManager.handleSignal), false, 'listener has been removed')
+  }
+
+  t.done()
+})
+
+test('forwards signals to child process', t => {
+  const proc = new EventEmitter()
+  proc.kill = (signal) => {
+    t.equal(signal, signalManager.forwardedSignals[0], 'child receives correct signal')
+    proc.emit('exit', { code: 0 })
+    for (const signal of signalManager.forwardedSignals) {
+      t.equal(process.listeners(signal).includes(signalManager.handleSignal), false, 'listener has been removed')
+    }
+    t.done()
+  }
+
+  signalManager.add(proc)
+  // passing the signal name here is necessary to fake the effects of actually receiving the signal
+  // per nodejs documentation signal handlers receive the name of the signal as their first parameter
+  // https://nodejs.org/api/process.html#process_signal_events
+  process.emit(signalManager.forwardedSignals[0], signalManager.forwardedSignals[0])
+})


### PR DESCRIPTION
this change adds handlers to ensure that signals are forwarded to child processes appropriately. handlers are not added until a process exists that should be monitored, and are removed as soon as all children have exited, carrying the first non-falsey exit code received from a child.

for: https://github.com/npm/cli/issues/1947
