### PR TITLE
do not set process.exitCode based on child exit

### DIFF
--- a/lib/signal-manager.js
+++ b/lib/signal-manager.js
@@ -33,8 +33,7 @@ const add = proc => {
   if (!handlersInstalled)
     setupListeners()
 
-  proc.once('exit', ({ code }) => {
-    process.exitCode = process.exitCode || code
+  proc.once('exit', () => {
     runningProcs.delete(proc)
     cleanupListeners()
   })

--- a/test/signal-manager.js
+++ b/test/signal-manager.js
@@ -22,13 +22,13 @@ test('adds only one handler for each signal, removes handlers when children have
     t.equal(handlers.length, 1, 'only has one handler')
   }
 
-  procOne.emit('exit', { code: 0 })
+  procOne.emit('exit', 0)
 
   for (const signal of signalManager.forwardedSignals) {
     t.equal(process.listeners(signal).includes(signalManager.handleSignal), true, 'did not remove listeners yet')
   }
 
-  procTwo.emit('exit', { code: 0 })
+  procTwo.emit('exit', 0)
 
   for (const signal of signalManager.forwardedSignals) {
     t.equal(process.listeners(signal).includes(signalManager.handleSignal), false, 'listener has been removed')
@@ -41,7 +41,7 @@ test('forwards signals to child process', t => {
   const proc = new EventEmitter()
   proc.kill = (signal) => {
     t.equal(signal, signalManager.forwardedSignals[0], 'child receives correct signal')
-    proc.emit('exit', { code: 0 })
+    proc.emit('exit', 0)
     for (const signal of signalManager.forwardedSignals) {
       t.equal(process.listeners(signal).includes(signalManager.handleSignal), false, 'listener has been removed')
     }


### PR DESCRIPTION
The child process's exit code should be ignored for the purpose of the
signal manager, and is not emitted by node's child_process.spawn in the
same way that @npmcli/promise-spawn returns it.

Fix: #11

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
