### PR TITLE
fix: do not throw on missing package.json

### DIFF
--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -6,7 +6,9 @@ const runScript = options => {
   validateOptions(options)
   const {pkg, path} = options
   return pkg ? runScriptPkg(options)
-    : rpj(path + '/package.json').then(pkg => runScriptPkg({...options, pkg}))
+    : rpj(path + '/package.json')
+      .then(pkg => runScriptPkg({...options, pkg}))
+      .catch(() => runScriptPkg({...options, pkg: { scripts: {} }}))
 }
 
 module.exports = runScript

--- a/test/run-script.js
+++ b/test/run-script.js
@@ -1,10 +1,11 @@
 const requireInject = require('require-inject')
 
-const runScript = requireInject('../lib/run-script.js', {
+const mocks = {
   '../lib/run-script-pkg.js': async x => x,
   '../lib/validate-options.js': () => {},
   'read-package-json-fast': async x => x,
-})
+}
+const runScript = requireInject('../lib/run-script.js', mocks)
 
 const t = require('tap')
 
@@ -13,6 +14,17 @@ t.test('no package provided, look up the package', t =>
     path: 'foo',
     pkg: 'foo/package.json',
   })))
+
+t.test('no package provided, look up the package fails', t => {
+  const runScript = requireInject('../lib/run-script.js', {
+    ...mocks,
+    'read-package-json-fast': () => Promise.reject(new Error('ERR'))
+  })
+  return runScript({ path: 'foo' }).then(res => t.strictSame(res, {
+    path: 'foo',
+    pkg: { scripts: {} },
+  }))
+})
 
 t.test('package provided, skip look up', t =>
   runScript({ path: 'foo', pkg: 'bar' }).then(res => t.strictSame(res, {


### PR DESCRIPTION
This fixes running `npm exec` in folders that does not have a `package.json` since `runScript` throws a `ENOENT` error.

**NOTE:** Not sure if throwing a `ENOENT` error on missing `package.json` is the intended behavior, if that's the case we can also simply patch its usage in `npm exec` by providing the empty `pkg: {scripts:{}}` arg 🤔 