### PR TITLE
fix: dont escape in non-cmd shells

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x]
+        platform:
+        - os: ubuntu-latest
+          shell: bash
+        - os: macos-latest
+          shell: bash
+        - os: windows-latest
+          shell: bash
+        - os: windows-latest
+          shell: powershell
+      fail-fast: false
+
+    runs-on: ${{ matrix.platform.os }}
+    defaults:
+      run:
+        shell: ${{ matrix.platform.shell }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v1.1.0
+
+      - name: Use Nodejs ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: npm install
+
+      # Run for all environments
+      - name: Run Tap Tests
+        run: npm test -- -c -t0

--- a/lib/make-spawn-args.js
+++ b/lib/make-spawn-args.js
@@ -34,7 +34,7 @@ const makeSpawnArgs = options => {
   } = options
 
   const isCmd = /(?:^|\\)cmd(?:\.exe)?$/i.test(scriptShell)
-  const args = isCmd ? ['/d', '/s', '/c', escapeCmd(cmd)] : ['-c', escapeCmd(cmd)]
+  const args = isCmd ? ['/d', '/s', '/c', escapeCmd(cmd)] : ['-c', cmd]
 
   const spawnOpts = {
     env: setPATH(path, {

--- a/lib/set-path.js
+++ b/lib/set-path.js
@@ -1,6 +1,8 @@
 const {resolve, dirname} = require('path')
 const isWindows = require('./is-windows.js')
-const nodeGypPath = resolve(__dirname, 'node-gyp-bin')
+// the path here is relative, even though it does not need to be
+// in order to make the posix tests pass in windows
+const nodeGypPath = resolve(__dirname, '../lib/node-gyp-bin')
 
 // Windows typically calls its PATH environ 'Path', but this is not
 // guaranteed, nor is it guaranteed to be the only one.  Merge them

--- a/test/make-spawn-args.js
+++ b/test/make-spawn-args.js
@@ -46,7 +46,7 @@ if (isWindows) {
       cmd: 'script "quoted parameter"; second command',
     }), [
       'blrorp',
-      [ '-c', `script "quoted parameter"& second command` ],
+      [ '-c', `script "quoted parameter"; second command` ],
       {
         env: {
           npm_package_json: /package\.json$/,
@@ -91,7 +91,7 @@ if (isWindows) {
       cmd: 'script "quoted parameter"; second command',
     }), [
       'sh',
-      [ '-c', `script 'quoted parameter'; second command` ],
+      [ '-c', `script "quoted parameter"; second command` ],
       {
         env: {
           npm_package_json: /package\.json$/,

--- a/test/set-path.js
+++ b/test/set-path.js
@@ -60,7 +60,7 @@ if (isWindows) {
       '/x/y/node_modules/.bin:' +
       '/x/node_modules/.bin:' +
       '/node_modules/.bin:' +
-      require('path').resolve(__dirname, '../lib/node-gyp-bin') + ':' +
+      require('path').posix.resolve(__dirname, '../lib/node-gyp-bin') + ':' +
       '/usr/local/bin:' +
       '/usr/local/sbin:' +
       '/usr/bin:' +


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
this skips the escaping in non-cmd shell environments. performing that escaping swaps double quotes for single quotes, which breaks shell expansion of globs and environment variables. this restores the previous behavior of only escaping in windows environments and specifically when the shell is cmd.exe

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Fixes https://github.com/npm/cli/issues/2193
