### PR TITLE
fix: escape empty arguments

### DIFF
--- a/lib/make-spawn-args.js
+++ b/lib/make-spawn-args.js
@@ -3,24 +3,9 @@ const isWindows = require('./is-windows.js')
 const setPATH = require('./set-path.js')
 const {resolve} = require('path')
 const npm_config_node_gyp = require.resolve('node-gyp/bin/node-gyp.js')
-const { quoteForShell, ShellString, ShellStringText, ShellStringUnquoted } = require('puka')
+const { ShellString } = require('puka')
 
-const escapeCmd = cmd => {
-  const result = []
-  const parsed = ShellString.sh([cmd])
-  for (const child of parsed.children) {
-    if (child instanceof ShellStringText) {
-      const children = child.contents.filter(segment => segment !== null).map(segment => quoteForShell(segment, false, isWindows && 'win32'))
-      result.push(...children)
-    } else if (child instanceof ShellStringUnquoted) {
-      result.push(child.value)
-    } else {
-      result.push(isWindows ? '&' : ';')
-    }
-  }
-
-  return result.join('')
-}
+const escapeCmd = cmd => ShellString.sh([cmd]).toString(isWindows && 'win32')
 
 const makeSpawnArgs = options => {
   const {

--- a/test/make-spawn-args.js
+++ b/test/make-spawn-args.js
@@ -59,6 +59,27 @@ if (isWindows) {
       }
     ])
 
+    // empty string
+    t.match(makeSpawnArgs({
+      event: 'event',
+      path: 'path',
+      cmd: 'script ""; second command',
+      scriptShell: 'cmd.exe',
+    }), [
+      'cmd.exe',
+      [ '/d', '/s', '/c', `script ""& second command` ],
+      {
+        env: {
+          npm_package_json: /package\.json$/,
+          npm_lifecycle_event: 'event',
+          npm_lifecycle_script: 'script'
+        },
+        stdio: undefined,
+        cwd: 'path',
+        windowsVerbatimArguments: true,
+      }
+    ])
+
     t.match(makeSpawnArgs({
       event: 'event',
       path: 'path',


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
A try to fix #19 .

I read https://gitlab.com/rhendric/puka/-/blob/v1.0.1/src/sh.js#L30
and understood that `sh` is equivalent to `ShellString.sh(...).toString()`.

Although examples of https://gitlab.com/rhendric/puka/-/tree/v1.0.1#quoteforshell
applies `quoteForShell` only for `sh` template arguments ,

the format function of https://gitlab.com/rhendric/puka/-/blob/v1.0.1/src/ShellStringText.js
delegated by https://gitlab.com/rhendric/puka/-/blob/v1.0.1/src/ShellString.js#L49
also quotes parsed arguments of a `sh` template string .

The format function of `ShellStringText` uses `formatter.quote`
which actually is `quoteForCmd` registered in
https://gitlab.com/rhendric/puka/-/blob/v1.0.1/src/Formatter.js
and is equivalent to `quoteForShell` as seen in
https://gitlab.com/rhendric/puka/-/blob/v1.0.1/src/quoteForShell.js .

That means `ShellString.sh(...).toString()` virtually applies `quoteForShell`
to parsed arguments of a `sh` template string .

Although `ShellString.sh(...).toString()` does not have `forceQuote` parameter ,
`escapeCmd` in make-spawn-args passes `false` as `forceQuote` to `quoteForShell` and
the default of `forceQuote` is falsy as seen in
https://gitlab.com/rhendric/puka/-/blob/v1.0.1/src/Formatter.js#L72 and
https://gitlab.com/rhendric/puka/-/blob/v1.0.1/src/Formatter.js#L54 .
(But one of uses of `formatter.quote` in `ShellStringText` passes `true` as `quoteForShell`
as seee in
https://gitlab.com/rhendric/puka/-/blob/v1.0.1/src/ShellStringText.js#L46 .
This may cause incompatibility. )

Thus I think replacing `escapeCmd` in make-spawn-args with `ShellString.sh(...).toString()`
is safe .

One of the differences is that `ShellString.sh(...).toString()` replaces an empty string
with a quoted empty string as seen in
https://gitlab.com/rhendric/puka/-/blob/v1.0.1/src/ShellStringText.js#L54
and
https://gitlab.com/rhendric/puka/-/blob/v1.0.1/src/Formatter.js#L30 .

I added a test case for escaping empty arguments in windows environment
and run `npm run test` with node v15.8.0 and npm 7.5.2 on windows 10 cmd.exe .

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
  Fixes #19
