### PR TITLE
[fix] node v10.0 lacks `fs.promises`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: ['10.0', 10.x, '12.0', 12.x, '14.0', 14.x]
         platform:
         - os: ubuntu-latest
           shell: bash

--- a/lib/is-server-package.js
+++ b/lib/is-server-package.js
@@ -1,4 +1,6 @@
-const { stat } = require('fs').promises
+const util = require('util')
+const fs = require('fs')
+const { stat } = fs.promises || { stat: util.promisify(fs.stat) }
 const { resolve } = require('path')
 module.exports = async path => {
   try {

--- a/test/is-server-package.js
+++ b/test/is-server-package.js
@@ -1,4 +1,5 @@
 const t = require('tap')
+const requireInject = require('require-inject')
 const isServerPackage = require('../lib/is-server-package.js')
 
 t.test('returns true if server.js present', async t => {
@@ -18,4 +19,8 @@ t.test('returns false if server.js not a file', async t => {
     'server.js': {}
   })
   t.equal(await isServerPackage(path), false)
+})
+
+t.test('works without fs.promises', async t => {
+  t.doesNotThrow(() => requireInject('../lib/is-server-package', { fs: { ...require('fs'), promises: null }}))
 })


### PR DESCRIPTION
In this node version, fall back to `util.promisify` of the callback version.

Maybe fixes https://github.com/npm/cli/issues/2623. Maybe fixes https://github.com/npm/cli/issues/2652. Maybe fixes https://github.com/npm/cli/issues/2625.

Updated the tests to run on the `.0`s as well.