### PR TITLE
fix: windows ComSpec env variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ terminal, then it is up to the user to end it, of course.
   - The `package.json` fields described in
     [RFC183](https://github.com/npm/rfcs/pull/183/files).
 - `scriptShell` Optional, defaults to `/bin/sh` on Unix, defaults to
-  `env.comspec` or `cmd` on Windows.  Custom script to use to execute the
+  `env.ComSpec` or `cmd` on Windows.  Custom script to use to execute the
   command.
 - `stdio` Optional, defaults to `'pipe'`.  The same as the `stdio` argument
   passed to `child_process` functions in Node.js.  Note that if a stdio

--- a/lib/make-spawn-args.js
+++ b/lib/make-spawn-args.js
@@ -8,7 +8,7 @@ const makeSpawnArgs = options => {
   const {
     event,
     path,
-    scriptShell = isWindows ? process.env.comspec || 'cmd' : 'sh',
+    scriptShell = isWindows ? process.env.ComSpec || 'cmd' : 'sh',
     env = {},
     stdio,
     cmd,

--- a/test/make-spawn-args.js
+++ b/test/make-spawn-args.js
@@ -16,8 +16,8 @@ const makeSpawnArgs = requireInject('../lib/make-spawn-args.js', {
 
 if (isWindows) {
   t.test('windows', t => {
-    // with no comspec
-    delete process.env.comspec
+    // with no ComSpec
+    delete process.env.ComSpec
     t.match(makeSpawnArgs({
       event: 'event',
       path: 'path',
@@ -38,8 +38,8 @@ if (isWindows) {
       }
     ])
 
-    // with a funky comspec
-    process.env.comspec = 'blrorp'
+    // with a funky ComSpec
+    process.env.ComSpec = 'blrorp'
     t.match(makeSpawnArgs({
       event: 'event',
       path: 'path',


### PR DESCRIPTION
This looks like a typo in the original implementation, based on
references to this same variable in the npm cli config and elsewhere:

- npm cli: https://github.com/npm/cli/blob/a4e7f4e4b40d645fed97622a97c7fa72aa5da82b/lib/utils/config/definitions.js#L59
- node docs: https://nodejs.org/dist/latest-v14.x/docs/api/child_process.html#child_process_child_process_spawn_command_args_options
