### PR TITLE
Remove infer-owner from dependencies (not used)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@npmcli/node-gyp": "^1.0.2",
         "@npmcli/promise-spawn": "^1.3.2",
-        "infer-owner": "^1.0.4",
         "node-gyp": "^7.1.0",
         "read-package-json-fast": "^2.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "dependencies": {
     "@npmcli/node-gyp": "^1.0.2",
     "@npmcli/promise-spawn": "^1.3.2",
-    "infer-owner": "^1.0.4",
     "node-gyp": "^7.1.0",
     "read-package-json-fast": "^2.0.1"
   },


### PR DESCRIPTION
This PR remove the package infer-owner from direct dependencies (because not used here).

The package will remain in the package-lock.json because he is still used by other dependencies.