### PR TITLE
changed extra args to array passing without JSON parsing.

### DIFF
--- a/lib/make-spawn-args.js
+++ b/lib/make-spawn-args.js
@@ -12,11 +12,12 @@ const makeSpawnArgs = options => {
     env = {},
     stdio,
     cmd,
+    cmdargs = [],
     stdioString = false,
   } = options
 
   const isCmd = /(?:^|\\)cmd(?:\.exe)?$/i.test(scriptShell)
-  const args = isCmd ? ['/d', '/s', '/c', cmd] : ['-c', cmd]
+  const args = isCmd ? ['/d', '/s', '/c', cmd, ...cmdargs] : ['-c', cmd, ...cmdargs]
 
   const spawnOpts = {
     env: setPATH(path, {

--- a/lib/run-script-pkg.js
+++ b/lib/run-script-pkg.js
@@ -28,10 +28,12 @@ const runScriptPkg = async options => {
 
   const { scripts = {}, gypfile } = pkg
   let cmd = null
+  let cmdargs = []
   if (options.cmd) {
     cmd = options.cmd
   } else if (pkg.scripts && pkg.scripts[event]) {
-    cmd = pkg.scripts[event] + args.map(a => ` ${JSON.stringify(a)}`).join('')
+    cmd = pkg.scripts[event]
+    cmdargs = args
   } else if (
     // If there is no preinstall or install script, default to rebuilding node-gyp packages.
     event === 'install' &&
@@ -42,16 +44,19 @@ const runScriptPkg = async options => {
   ) {
     cmd = defaultGypInstallScript
   } else if (event === 'start' && await isServerPackage(path)) {
-    cmd = 'node server.js' + args.map(a => ` ${JSON.stringify(a)}`).join('')
+    cmd = 'node server.js'
+    cmdargs = args
   }
 
   if (!cmd) {
     return { code: 0, signal: null }
   }
 
+  const script = cmd + cmdargs.map(a => ` ${JSON.stringify(a)}`).join('')
+
   if (stdio === 'inherit' && banner !== false) {
     // we're dumping to the parent's stdout, so print the banner
-    console.log(bruce(pkg._id, event, cmd))
+    console.log(bruce(pkg._id, event, script))
   }
 
   const p = promiseSpawn(...makeSpawnArgs({
@@ -61,10 +66,11 @@ const runScriptPkg = async options => {
     env: packageEnvs(env, pkg),
     stdio,
     cmd,
+    cmdargs,
     stdioString,
   }), {
     event,
-    script: cmd,
+    script,
     pkgid: pkg._id,
     path,
   })


### PR DESCRIPTION
<!-- What / Why -->
Suggest ideas for solving the escape problem in windows.

<!-- Describe the request in detail. What it does and why it's being changed. -->
This idea does not execute escape programmatically.
I pass extra args as an array to the shell(cmd.exe, sh) and expect the shell to escape.

## References
https://github.com/npm/run-script/pull/31
