### PR TITLE
fix: remove invalid characters from filename

### DIFF
--- a/lib/escape.js
+++ b/lib/escape.js
@@ -65,7 +65,13 @@ const sh = (input) => {
   return result
 }
 
+// disabling the no-control-regex rule for this line as we very specifically _do_ want to
+// replace those characters if they somehow exist at this point, which is highly unlikely
+// eslint-disable-next-line no-control-regex
+const filename = (input) => input.replace(/[<>:"/\\|?*\x00-\x31]/g, '')
+
 module.exports = {
   cmd,
   sh,
+  filename,
 }

--- a/lib/make-spawn-args.js
+++ b/lib/make-spawn-args.js
@@ -30,6 +30,7 @@ const makeSpawnArgs = options => {
     npm_config_node_gyp,
   })
 
+  const fileName = escape.filename(`${event}-${Date.now()}`)
   let scriptFile
   let script = ''
 
@@ -61,7 +62,7 @@ const makeSpawnArgs = options => {
 
     const doubleEscape = pathToInitial.endsWith('.cmd') || pathToInitial.endsWith('.bat')
 
-    scriptFile = resolve(tmpdir(), `${event}-${Date.now()}.cmd`)
+    scriptFile = resolve(tmpdir(), `${fileName}.cmd`)
     script += '@echo off\n'
     script += cmd
     if (args.length) {
@@ -71,7 +72,7 @@ const makeSpawnArgs = options => {
     const shebang = isAbsolute(scriptShell)
       ? `#!${scriptShell}`
       : `#!/usr/bin/env ${scriptShell}`
-    scriptFile = resolve(tmpdir(), `${event}-${Date.now()}.sh`)
+    scriptFile = resolve(tmpdir(), `${fileName}.sh`)
     script += `${shebang}\n`
     script += cmd
     if (args.length) {

--- a/package.json
+++ b/package.json
@@ -17,10 +17,6 @@
     "posttest": "npm run lint",
     "template-oss-apply": "template-oss-apply --force"
   },
-  "tap": {
-    "check-coverage": true,
-    "coverage-map": "map.js"
-  },
   "devDependencies": {
     "@npmcli/eslint-config": "^3.0.1",
     "@npmcli/template-oss": "3.5.0",


### PR DESCRIPTION
closes npm/cli#5066
