### PR TITLE
Add which to dependencies for yarn berry

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "@npmcli/node-gyp": "^2.0.0",
     "@npmcli/promise-spawn": "^3.0.0",
     "node-gyp": "^9.0.0",
-    "read-package-json-fast": "^2.0.3"
+    "read-package-json-fast": "^2.0.3",
+    "which": "^2.0.2"
   },
   "files": [
     "bin/",


### PR DESCRIPTION
<!-- What / Why -->
This PR adds `which` as a dependency of this project which should make yarn berry projects happy.

<!-- Describe the request in detail. What it does and why it's being changed. -->

When using this package in a yarn berry project, yarn berry complains about it trying to access `which`.

```shell

Error: @npmcli/run-script tried to access which, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

Required package: which
Required by: @npmcli/run-script@npm:4.1.3 (via /Users/jackwestbrook/Projects/grafana/.yarn/cache/@npmcli-run-script-npm-4.1.3-e85355f10b-62fb1a0e12.zip/node_modules/@npmcli/run-script/lib/)

Require stack:
- /Users/jackwestbrook/Projects/grafana/.yarn/cache/@npmcli-run-script-npm-4.1.3-e85355f10b-62fb1a0e12.zip/node_modules/@npmcli/run-script/lib/make-spawn-args.js

```
Looking at the code it appears [make-spawn-args.js](https://github.com/npm/run-script/blob/2354d064e6ef833d9797bf70c333455f075d1b3b/lib/make-spawn-args.js#L7) does indeed pull in the nested `which` dependency.


This results in needing to add the following to `.yarnrc.yml` in a yarn berry project:

```yml
packageExtensions:
  "@npmcli/run-script@4.1.3":
    dependencies:
      which: ^2.0.2
```

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
