### PR TITLE
fix: unique filename for temporary script files

### DIFF
--- a/lib/make-spawn-args.js
+++ b/lib/make-spawn-args.js
@@ -7,6 +7,7 @@ const { isAbsolute, resolve } = require('path')
 const which = require('which')
 const npm_config_node_gyp = require.resolve('node-gyp/bin/node-gyp.js')
 const escape = require('./escape.js')
+const { randomBytes } = require('crypto')
 
 const makeSpawnArgs = options => {
   const {
@@ -30,7 +31,7 @@ const makeSpawnArgs = options => {
     npm_config_node_gyp,
   })
 
-  const fileName = escape.filename(`${event}-${Date.now()}`)
+  const fileName = escape.filename(`${event}-${randomBytes(4).toString('hex')}`)
   let scriptFile
   let script = ''
 


### PR DESCRIPTION
<!-- What / Why -->
Use unique filenames for temporary script files to avoid npm throwing text file busy errors
<!-- Describe the request in detail. What it does and why it's being changed. -->
Switch from `Date.now()` to `crypto.randomBytes(4).toString('hex')`

## References
  Fixes https://github.com/npm/run-script/issues/91
  Closes https://github.com/npm/run-script/issues/91

## Code References
https://github.com/npm/run-script/blob/6493397a91239c19d00757ccc8d6131bbfab363d/lib/make-spawn-args.js#L33
https://github.com/npm/cli/blob/9d6f3f9c410753bf9412ddfeac6a000feccd14f0/lib/npm.js#L447-L448