### PR TITLE
fix: correctly translate paths when using bash in windows

### DIFF
--- a/lib/make-spawn-args.js
+++ b/lib/make-spawn-args.js
@@ -1,13 +1,19 @@
 /* eslint camelcase: "off" */
 const isWindows = require('./is-windows.js')
 const setPATH = require('./set-path.js')
-const { chmodSync: chmod, unlinkSync: unlink, writeFileSync: writeFile } = require('fs')
+const { unlinkSync: unlink, writeFileSync: writeFile } = require('fs')
 const { tmpdir } = require('os')
-const { isAbsolute, resolve } = require('path')
+const { resolve } = require('path')
 const which = require('which')
 const npm_config_node_gyp = require.resolve('node-gyp/bin/node-gyp.js')
 const escape = require('./escape.js')
 const { randomBytes } = require('crypto')
+
+const translateWinPathToPosix = (path) => {
+  return path
+    .replace(/^([A-z]):/, '/$1')
+    .replace(/\\/g, '/')
+}
 
 const makeSpawnArgs = options => {
   const {
@@ -70,24 +76,17 @@ const makeSpawnArgs = options => {
       script += ` ${args.map((arg) => escape.cmd(arg, doubleEscape)).join(' ')}`
     }
   } else {
-    const shebang = isAbsolute(scriptShell)
-      ? `#!${scriptShell}`
-      : `#!/usr/bin/env ${scriptShell}`
     scriptFile = resolve(tmpdir(), `${fileName}.sh`)
-    script += `${shebang}\n`
-    script += cmd
+    script = cmd
     if (args.length) {
       script += ` ${args.map((arg) => escape.sh(arg)).join(' ')}`
     }
   }
 
   writeFile(scriptFile, script)
-  if (!isCmd) {
-    chmod(scriptFile, '0775')
-  }
   const spawnArgs = isCmd
     ? ['/d', '/s', '/c', escape.cmd(scriptFile)]
-    : ['-c', escape.sh(scriptFile)]
+    : [isWindows ? translateWinPathToPosix(scriptFile) : scriptFile]
 
   const spawnOpts = {
     env: spawnEnv,


### PR DESCRIPTION
this fixes the issue when using bash as the script-shell in windows, the problem was that we were passing a windows path to bash as a script to run. to correct it, we translate `C:` to `/c` and replace all backslashes with forward slashes. as an example, `C:\\Directory\\filename` becomes `/C/Directory/filename`

correcting this problem brought to light a few things that make the module simpler:

1. we no longer need a shebang, or the `-c` flag when using bash
2. we no longer need to `chmod +x` the script file
3. we no longer need to escape the filename passed as an argument to bash
4. we no longer spawn a bash that spawns another bash to run your script

no changes were made to the cmd.exe behavior

closes #90
