### PR TITLE
fix: remove the temp file entirely

### DIFF
--- a/lib/escape.js
+++ b/lib/escape.js
@@ -36,13 +36,10 @@ const cmd = (input, doubleEscape) => {
   }
 
   // and finally, prefix shell meta chars with a ^
-  result = result.replace(/[ !^&()<>|"]/g, '^$&')
+  result = result.replace(/[ !%^&()<>|"]/g, '^$&')
   if (doubleEscape) {
-    result = result.replace(/[ !^&()<>|"]/g, '^$&')
+    result = result.replace(/[ !%^&()<>|"]/g, '^$&')
   }
-
-  // except for % which is escaped with another %, and only once
-  result = result.replace(/%/g, '%%')
 
   return result
 }
@@ -65,13 +62,7 @@ const sh = (input) => {
   return result
 }
 
-// disabling the no-control-regex rule for this line as we very specifically _do_ want to
-// replace those characters if they somehow exist at this point, which is highly unlikely
-// eslint-disable-next-line no-control-regex
-const filename = (input) => input.replace(/[<>:"/\\|?*\x00-\x1F]/g, '')
-
 module.exports = {
   cmd,
   sh,
-  filename,
 }

--- a/lib/run-script-pkg.js
+++ b/lib/run-script-pkg.js
@@ -55,7 +55,7 @@ const runScriptPkg = async options => {
     console.log(bruce(pkg._id, event, cmd))
   }
 
-  const [spawnShell, spawnArgs, spawnOpts, cleanup] = makeSpawnArgs({
+  const [spawnShell, spawnArgs, spawnOpts] = makeSpawnArgs({
     event,
     path,
     scriptShell,
@@ -93,7 +93,7 @@ const runScriptPkg = async options => {
     } else {
       throw er
     }
-  }).finally(cleanup)
+  })
 }
 
 module.exports = runScriptPkg

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "postlint": "template-oss-check",
     "snap": "tap",
     "posttest": "npm run lint",
-    "template-oss-apply": "template-oss-apply --force",
-    "foo": "echo \"a\nb\""
+    "template-oss-apply": "template-oss-apply --force"
   },
   "devDependencies": {
     "@npmcli/eslint-config": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "postlint": "template-oss-check",
     "snap": "tap",
     "posttest": "npm run lint",
-    "template-oss-apply": "template-oss-apply --force"
+    "template-oss-apply": "template-oss-apply --force",
+    "foo": "echo \"a\nb\""
   },
   "devDependencies": {
     "@npmcli/eslint-config": "^3.0.1",


### PR DESCRIPTION
fixes npm/cli#5195

the use of the temp file was technically a breaking change for folks using cmd.exe as their script-shell, i.e. our default in windows.

the specific breakage is that when used in a file, you must escape the `%` as `%%` but _only_ when running your script from a file. it's subtle, but this means by default our windows users would have to modify their scripts to ensure the `%` is escaped. by removing the temp file, we fix this breakage.
