### PR TITLE
fix: add arguments back to the logged banner

### DIFF
--- a/lib/run-script-pkg.js
+++ b/lib/run-script-pkg.js
@@ -6,8 +6,17 @@ const signalManager = require('./signal-manager.js')
 const isServerPackage = require('./is-server-package.js')
 
 // you wouldn't like me when I'm angry...
-const bruce = (id, event, cmd) =>
-  `\n> ${id ? id + ' ' : ''}${event}\n> ${cmd.trim().replace(/\n/g, '\n> ')}\n`
+const bruce = (id, event, cmd, args) => {
+  let banner = id
+    ? `\n> ${id} ${event}\n`
+    : `\n> ${event}\n`
+  banner += `> ${cmd.trim().replace(/\n/g, '\n> ')}`
+  if (args.length) {
+    banner += ` ${args.join(' ')}`
+  }
+  banner += '\n'
+  return banner
+}
 
 const runScriptPkg = async options => {
   const {
@@ -52,7 +61,7 @@ const runScriptPkg = async options => {
 
   if (stdio === 'inherit' && banner !== false) {
     // we're dumping to the parent's stdout, so print the banner
-    console.log(bruce(pkg._id, event, cmd))
+    console.log(bruce(pkg._id, event, cmd, args))
   }
 
   const [spawnShell, spawnArgs, spawnOpts] = makeSpawnArgs({

--- a/test/run-script-pkg.js
+++ b/test/run-script-pkg.js
@@ -239,6 +239,7 @@ t.test('do the banner with no pkgid', t => {
     },
     stdio: 'inherit',
     cmd: 'bar',
+    args: ['baz', 'buzz'],
     pkg: {
       scripts: {},
     },
@@ -247,19 +248,19 @@ t.test('do the banner with no pkgid', t => {
     event: 'foo',
     path: 'path',
     scriptShell: 'sh',
-    args: [],
     binPaths: false,
     env: {
       environ: 'value',
     },
     stdio: 'inherit',
     cmd: 'bar',
+    args: ['baz', 'buzz'],
   }, {
     event: 'foo',
     script: 'bar',
     path: 'path',
     pkgid: undefined,
-  }])).then(() => t.strictSame(logs, [['\n> foo\n> bar\n']]))
+  }])).then(() => t.strictSame(logs, [['\n> foo\n> bar baz buzz\n']]))
 })
 
 t.test('pkg has foo script', t => runScriptPkg({


### PR DESCRIPTION
when we implemented the temp file for scripts, a subtle thing that we lost was the banner logging both the script itself as well as the arguments it received. this pull request restores that behavior, which i think is more clear and helpful for our users

current behavior (in this repo):
```
❯ npm test -- --coverage-report=html

> @npmcli/run-script@4.2.0 test
> tap
```

new behavior:
```
❯ npm test -- --coverage-report=html

> @npmcli/run-script@4.2.0 test
> tap --coverage-report=html
```