### PR TITLE
feat!: dont set a default for `stdioString`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ runScript({
   // optional, defaults to /bin/sh on unix, or cmd.exe on windows
   scriptShell: '/bin/bash',
 
-  // optional, defaults to false
+  // optional, passed directly to `@npmcli/promise-spawn` which defaults it to true
   // return stdout and stderr as strings rather than buffers
-  stdioString: true,
+  stdioString: false,
 
   // optional, additional environment variables to add
   // note that process.env IS inherited by default
@@ -121,8 +121,9 @@ terminal, then it is up to the user to end it, of course.
   the result/error object.
 - `cmd` Optional.  Override the script from the `package.json` with
   something else, which will be run in an otherwise matching environment.
-- `stdioString` Optional, defaults to `false`.  Return string values for
-  `stderr` and `stdout` rather than Buffers.
+- `stdioString` Optional, passed directly to `@npmcli/promise-spawn` which
+  defaults it to `true`.  Return string values for `stderr` and `stdout` rather
+  than Buffers.
 - `banner` Optional, defaults to `true`.  If the `stdio` option is set to
   `'inherit'`, then print a banner with the package name and version, event
   name, and script command to be run.  Set explicitly to `false` to disable

--- a/lib/make-spawn-args.js
+++ b/lib/make-spawn-args.js
@@ -13,7 +13,7 @@ const makeSpawnArgs = options => {
     stdio,
     cmd,
     args = [],
-    stdioString = false,
+    stdioString,
   } = options
 
   const spawnEnv = setPATH(path, binPaths, {

--- a/lib/run-script-pkg.js
+++ b/lib/run-script-pkg.js
@@ -28,7 +28,7 @@ const runScriptPkg = async options => {
     stdio = 'pipe',
     pkg,
     args = [],
-    stdioString = false,
+    stdioString,
     // note: only used when stdio:inherit
     banner = true,
     // how long to wait for a process.kill signal

--- a/test/run-script-pkg.js
+++ b/test/run-script-pkg.js
@@ -55,7 +55,7 @@ t.test('pkg has server.js, start not specified', async t => {
     },
   })
   t.strictSame(res, ['sh', ['-c', 'node server.js'], {
-    stdioString: false,
+    stdioString: undefined,
     event: 'start',
     path,
     scriptShell: 'sh',
@@ -92,7 +92,7 @@ t.test('pkg has server.js, start not specified, with args', async t => {
     },
   })
   t.strictSame(res, ['sh', ['-c', 'node server.js'], {
-    stdioString: false,
+    stdioString: undefined,
     event: 'start',
     path,
     scriptShell: 'sh',
@@ -130,7 +130,7 @@ t.test('pkg has no foo script, but custom cmd provided', t => runScriptPkg({
     scripts: {},
   },
 }).then(res => t.strictSame(res, ['sh', ['-c', 'bar'], {
-  stdioString: false,
+  stdioString: undefined,
   event: 'foo',
   path: 'path',
   scriptShell: 'sh',
@@ -167,7 +167,7 @@ t.test('do the banner when stdio is inherited, handle line breaks', t => {
       scripts: {},
     },
   }).then(res => t.strictSame(res, ['sh', ['-c', 'bar\nbaz\n'], {
-    stdioString: false,
+    stdioString: undefined,
     event: 'foo',
     path: 'path',
     scriptShell: 'sh',
@@ -206,7 +206,7 @@ t.test('do not show banner when stdio is inherited, if suppressed', t => {
     },
     banner: false,
   }).then(res => t.strictSame(res, ['sh', ['-c', 'bar'], {
-    stdioString: false,
+    stdioString: undefined,
     event: 'foo',
     path: 'path',
     scriptShell: 'sh',
@@ -244,7 +244,7 @@ t.test('do the banner with no pkgid', t => {
       scripts: {},
     },
   }).then(res => t.strictSame(res, ['sh', ['-c', 'bar'], {
-    stdioString: false,
+    stdioString: undefined,
     event: 'foo',
     path: 'path',
     scriptShell: 'sh',
@@ -278,7 +278,7 @@ t.test('pkg has foo script', t => runScriptPkg({
     },
   },
 }).then(res => t.strictSame(res, ['sh', ['-c', 'bar'], {
-  stdioString: false,
+  stdioString: undefined,
   event: 'foo',
   path: 'path',
   scriptShell: 'sh',
@@ -313,7 +313,7 @@ t.test('pkg has foo script, with args', t => runScriptPkg({
   args: ['a', 'b', 'c'],
   binPaths: false,
 }).then(res => t.strictSame(res, ['sh', ['-c', 'bar'], {
-  stdioString: false,
+  stdioString: undefined,
   event: 'foo',
   path: 'path',
   scriptShell: 'sh',
@@ -361,7 +361,7 @@ t.test('pkg has no install or preinstall script, but node-gyp files are present'
       env: { environ: 'value' },
       stdio: 'pipe',
       cmd: 'node-gyp rebuild',
-      stdioString: false,
+      stdioString: undefined,
     },
     {
       event: 'install',
@@ -422,7 +422,7 @@ t.test('end stdin if present', async t => {
     env: {},
     stdio: 'pipe',
     cmd: 'cat',
-    stdioString: false,
+    stdioString: undefined,
   }, {
     event: 'cat',
     script: 'cat',


### PR DESCRIPTION
BREAKING CHANGE: `stdioString` is no longer set to `false` by default.
Instead it is not set and passed directory to `@npmcli/promise-spawn`
which defaults it to `true`.
