### PR TITLE
fix(envs): revert behavior of array in npm config

### DIFF
--- a/lib/package-envs.js
+++ b/lib/package-envs.js
@@ -1,19 +1,19 @@
 // https://github.com/npm/rfcs/pull/183
 
-const envVal = val => Array.isArray(val) ? val.map(v => envVal(v)).join('\n\n')
-  : val === null || val === false ? ''
-  : String(val)
+const envVal = val => val === null || val === false ? '' : String(val)
 
 const packageEnvs = (env, vals, prefix) => {
   for (const [key, val] of Object.entries(vals)) {
     if (val === undefined) {
       continue
-    } else if (val && !Array.isArray(val) && typeof val === 'object') {
-      packageEnvs(env, val, `${prefix}${key}_`)
-    } else if (Array.isArray(val)) {
-      val.forEach((item, index) => {
-        env[`${prefix}${key}_${index}`] = envVal(item)
-      })
+    } else if (val && typeof val === 'object') {
+      if (Array.isArray(val)) {
+        val.forEach((item, index) => {
+          packageEnvs(env, { [`${key}_${index}`]: item }, `${prefix}`)
+        })
+      } else {
+        packageEnvs(env, val, `${prefix}${key}_`)
+      }
     } else {
       env[`${prefix}${key}`] = envVal(val)
     }

--- a/lib/package-envs.js
+++ b/lib/package-envs.js
@@ -10,6 +10,10 @@ const packageEnvs = (env, vals, prefix) => {
       continue
     } else if (val && !Array.isArray(val) && typeof val === 'object') {
       packageEnvs(env, val, `${prefix}${key}_`)
+    } else if (Array.isArray(val)) {
+      val.forEach((item, index) => {
+        env[`${prefix}${key}_${index}`] = envVal(item)
+      })
     } else {
       env[`${prefix}${key}`] = envVal(val)
     }

--- a/test/package-envs.js
+++ b/test/package-envs.js
@@ -27,7 +27,9 @@ t.strictSame(packageEnvs({}, {
   npm_package_config_zero: '0',
   npm_package_config_false: '',
   npm_package_config_nested_object_is_included: 'true',
-  npm_package_engines: 'array\n\nof\n\nstrings',
+  npm_package_engines_0: 'array',
+  npm_package_engines_1: 'of',
+  npm_package_engines_2: 'strings',
   npm_package_bin_foo: './bar.js',
   npm_package_bin_bar: '',
 })


### PR DESCRIPTION
This is a fix for [[BUG] package.json#/config/*: Array changed behaviour to joining items with double new-line #3775](https://github.com/npm/cli/issues/3775)

package.json:
```
{
"config": {
    "array": [
      "item1",
      "item2", "item3"
    ]
}}
```
Before:
```
{
  "npm_package_config_array": "item1\n\nitem2\n\nitem3"
}
```

After
```

{
  "npm_package_config_array_0": "item1",
  "npm_package_config_array_1": "item2",
  "npm_package_config_array_2": "item3"
}
```


## References
Closes https://github.com/npm/cli/issues/3775
