### PR TITLE
fix(envs): revert behavior of array in npm config

### DIFF
--- a/lib/package-envs.js
+++ b/lib/package-envs.js
@@ -1,5 +1,4 @@
-
-const packageEnvs = (env, vals, prefix) => {
+const packageEnvs = (vals, prefix, env = {}) => {
   for (const [key, val] of Object.entries(vals)) {
     if (val === undefined) {
       continue
@@ -7,10 +6,10 @@ const packageEnvs = (env, vals, prefix) => {
       env[`${prefix}${key}`] = ''
     } else if (Array.isArray(val)) {
       val.forEach((item, index) => {
-        packageEnvs(env, { [`${key}_${index}`]: item }, `${prefix}`)
+        packageEnvs({ [`${key}_${index}`]: item }, `${prefix}`, env)
       })
     } else if (typeof val === 'object') {
-      packageEnvs(env, val, `${prefix}${key}_`)
+      packageEnvs(val, `${prefix}${key}_`, env)
     } else {
       env[`${prefix}${key}`] = String(val)
     }
@@ -19,10 +18,12 @@ const packageEnvs = (env, vals, prefix) => {
 }
 
 // https://github.com/npm/rfcs/pull/183 defines which fields we put into the environment
-module.exports = (env, pkg) => packageEnvs({ ...env }, {
-  name: pkg.name,
-  version: pkg.version,
-  config: pkg.config,
-  engines: pkg.engines,
-  bin: pkg.bin,
-}, 'npm_package_')
+module.exports = pkg => {
+  return packageEnvs({
+    name: pkg.name,
+    version: pkg.version,
+    config: pkg.config,
+    engines: pkg.engines,
+    bin: pkg.bin,
+  }, 'npm_package_')
+}

--- a/lib/package-envs.js
+++ b/lib/package-envs.js
@@ -1,9 +1,6 @@
 // https://github.com/npm/rfcs/pull/183
 
 const envVal = val => {
-  if (Array.isArray(val)) {
-    return val.map(v => envVal(v)).join('\n\n')
-  }
   if (val === null || val === false) {
     return ''
   }
@@ -14,12 +11,14 @@ const packageEnvs = (env, vals, prefix) => {
   for (const [key, val] of Object.entries(vals)) {
     if (val === undefined) {
       continue
-    } else if (val && !Array.isArray(val) && typeof val === 'object') {
-      packageEnvs(env, val, `${prefix}${key}_`)
-    } else if (Array.isArray(val)) {
-      val.forEach((item, index) => {
-        env[`${prefix}${key}_${index}`] = envVal(item)
-      })
+    } else if (val && typeof val === 'object') {
+      if (Array.isArray(val)) {
+        val.forEach((item, index) => {
+          packageEnvs(env, { [`${key}_${index}`]: item }, `${prefix}`)
+        })
+      } else {
+        packageEnvs(env, val, `${prefix}${key}_`)
+      }
     } else {
       env[`${prefix}${key}`] = envVal(val)
     }

--- a/lib/package-envs.js
+++ b/lib/package-envs.js
@@ -16,6 +16,10 @@ const packageEnvs = (env, vals, prefix) => {
       continue
     } else if (val && !Array.isArray(val) && typeof val === 'object') {
       packageEnvs(env, val, `${prefix}${key}_`)
+    } else if (Array.isArray(val)) {
+      val.forEach((item, index) => {
+        env[`${prefix}${key}_${index}`] = envVal(item)
+      })
     } else {
       env[`${prefix}${key}`] = envVal(val)
     }

--- a/lib/package-envs.js
+++ b/lib/package-envs.js
@@ -1,31 +1,24 @@
-// https://github.com/npm/rfcs/pull/183
-
-const envVal = val => {
-  if (val === null || val === false) {
-    return ''
-  }
-  return String(val)
-}
 
 const packageEnvs = (env, vals, prefix) => {
   for (const [key, val] of Object.entries(vals)) {
     if (val === undefined) {
       continue
-    } else if (val && typeof val === 'object') {
-      if (Array.isArray(val)) {
-        val.forEach((item, index) => {
-          packageEnvs(env, { [`${key}_${index}`]: item }, `${prefix}`)
-        })
-      } else {
-        packageEnvs(env, val, `${prefix}${key}_`)
-      }
+    } else if (val === null || val === false) {
+      env[`${prefix}${key}`] = ''
+    } else if (Array.isArray(val)) {
+      val.forEach((item, index) => {
+        packageEnvs(env, { [`${key}_${index}`]: item }, `${prefix}`)
+      })
+    } else if (typeof val === 'object') {
+      packageEnvs(env, val, `${prefix}${key}_`)
     } else {
-      env[`${prefix}${key}`] = envVal(val)
+      env[`${prefix}${key}`] = String(val)
     }
   }
   return env
 }
 
+// https://github.com/npm/rfcs/pull/183 defines which fields we put into the environment
 module.exports = (env, pkg) => packageEnvs({ ...env }, {
   name: pkg.name,
   version: pkg.version,

--- a/lib/run-script-pkg.js
+++ b/lib/run-script-pkg.js
@@ -69,7 +69,7 @@ const runScriptPkg = async options => {
     path,
     scriptShell,
     binPaths,
-    env: packageEnvs(env, pkg),
+    env: { ...env, ...packageEnvs(pkg) },
     stdio,
     cmd,
     args,

--- a/test/make-spawn-args.js
+++ b/test/make-spawn-args.js
@@ -39,7 +39,8 @@ t.test('spawn args', async t => {
           e.env.npm_package_config_test_null === '' &&
           e.env.npm_package_config_test_false === '' &&
           e.env.npm_package_config_test_string === pkg.config.test_string &&
-          e.env.npm_package_config_test_array === pkg.config.test_array.join('\n\n') &&
+          e.env.npm_package_config_test_array_0 === pkg.config.test_array[0] &&
+          e.env.npm_package_config_test_array_1 === pkg.config.test_array[1] &&
           e.env.npm_package_bin === pkg.bin &&
           e.env.npm_package_engines_npm === pkg.engines.npm &&
           e.env.npm_package_engines_node === pkg.engines.node &&


### PR DESCRIPTION
Reverts environment parsing of config arrays to use indexed names
instead of joining them with double newlines.  That change appears to
have been introduced when the enviromnent values were added back into
npm, but not in the same way they were done before.

Fixes: https://github.com/npm/cli/issues/3775

Credit: @siemhesda
