### PR TITLE
fix: autolocation of node-gyp in make-spawn-args

### DIFF
--- a/lib/make-spawn-args.js
+++ b/lib/make-spawn-args.js
@@ -1,7 +1,15 @@
 /* eslint camelcase: "off" */
 const setPATH = require('./set-path.js')
 const { resolve } = require('path')
-const npm_config_node_gyp = require.resolve('node-gyp/bin/node-gyp.js')
+let npm_config_node_gyp
+try {
+  /* istanbul ignore next */
+  if (typeof require === 'function' && typeof require.resolve === 'function') {
+    npm_config_node_gyp = require.resolve('node-gyp/bin/node-gyp.js')
+  }
+} catch (er) {
+  /* istanbul ignore next */
+}
 
 const makeSpawnArgs = options => {
   const {
@@ -23,8 +31,11 @@ const makeSpawnArgs = options => {
     npm_package_json: resolve(path, 'package.json'),
     npm_lifecycle_event: event,
     npm_lifecycle_script: cmd,
-    npm_config_node_gyp,
   })
+  /* istanbul ignore next */
+  if (typeof npm_config_node_gyp === 'string') {
+    spawnEnv.npm_config_node_gyp = npm_config_node_gyp
+  }
 
   const spawnOpts = {
     env: spawnEnv,


### PR DESCRIPTION
- Prevents runtime error in environments where `require.resolve` is not available.
- Fall back to environment variable `npm_config_node_gyp` when node-gyp not resolved successfully.

### Related
- #23
- https://github.com/npm/cli/issues/2839