### PR TITLE
move banner to log event

### DIFF
--- a/lib/make-spawn-args.js
+++ b/lib/make-spawn-args.js
@@ -1,8 +1,7 @@
-/* eslint camelcase: "off" */
 const setPATH = require('./set-path.js')
 const { resolve } = require('path')
 
-let npm_config_node_gyp
+let npmConfigNodeGyp
 
 const makeSpawnArgs = options => {
   const {
@@ -20,13 +19,13 @@ const makeSpawnArgs = options => {
 
   if (nodeGyp) {
     // npm already pulled this from env and passes it in to options
-    npm_config_node_gyp = nodeGyp
+    npmConfigNodeGyp = nodeGyp
   } else if (env.npm_config_node_gyp) {
     // legacy mode for standalone user
-    npm_config_node_gyp = env.npm_config_node_gyp
+    npmConfigNodeGyp = env.npm_config_node_gyp
   } else {
     // default
-    npm_config_node_gyp = require.resolve('node-gyp/bin/node-gyp.js')
+    npmConfigNodeGyp = require.resolve('node-gyp/bin/node-gyp.js')
   }
 
   const spawnEnv = setPATH(path, binPaths, {
@@ -36,7 +35,7 @@ const makeSpawnArgs = options => {
     npm_package_json: resolve(path, 'package.json'),
     npm_lifecycle_event: event,
     npm_lifecycle_script: cmd,
-    npm_config_node_gyp,
+    npm_config_node_gyp: npmConfigNodeGyp,
   })
 
   const spawnOpts = {

--- a/lib/run-script-pkg.js
+++ b/lib/run-script-pkg.js
@@ -47,19 +47,13 @@ const runScriptPkg = async options => {
 
   let inputEnd = () => {}
   if (stdio === 'inherit') {
-    let banner
+    const { log, input } = require('proc-log')
     if (pkg._id) {
-      banner = `\n> ${pkg._id} ${event}\n`
+      log.notice('run', `${pkg._id} ${event}`)
     } else {
-      banner = `\n> ${event}\n`
+      log.notice('run', event)
     }
-    banner += `> ${cmd.trim().replace(/\n/g, '\n> ')}`
-    if (args.length) {
-      banner += ` ${args.join(' ')}`
-    }
-    banner += '\n'
-    const { output, input } = require('proc-log')
-    output.standard(banner)
+    log.notice('run', `${cmd.trim()} ${args?.join(' ')}`.trim())
     inputEnd = input.start()
   }
 

--- a/test/run-script-pkg.js
+++ b/test/run-script-pkg.js
@@ -7,17 +7,16 @@ const emptyDir = t.testdir({})
 
 const pkill = process.kill
 
-const output = []
-const appendOutput = (level, ...args) => {
-  if (level === 'standard') {
-    output.push([...args])
-  }
+const logs = []
+const logHandler = (level, ...args) => {
+  logs.push([level, ...args])
 }
-process.on('output', appendOutput)
-t.afterEach(() => output.length = 0)
-t.teardown(() => process.removeListener('output', appendOutput))
 
 t.test('run-script-pkg', async t => {
+  process.on('log', logHandler)
+  t.afterEach(() => logs.length = 0)
+  t.teardown(() => process.removeListener('log', logHandler))
+
   await t.test('stdio inherit no args and a pkgid', async t => {
     spawk.spawn('sh', a => a.includes('bar\nbaz\n'))
     await runScript({
@@ -34,7 +33,10 @@ t.test('run-script-pkg', async t => {
         scripts: {},
       },
     })
-    t.strictSame(output, [['\n> foo@1.2.3 foo\n> bar\n> baz\n']])
+    t.strictSame(logs, [
+      ['notice', 'run', 'foo@1.2.3 foo'],
+      ['notice', 'run', 'bar\nbaz'],
+    ])
     t.ok(spawk.done())
   })
 
@@ -54,7 +56,10 @@ t.test('run-script-pkg', async t => {
         scripts: {},
       },
     })
-    t.strictSame(output, [['\n> foo\n> bar baz buzz\n']])
+    t.strictSame(logs, [
+      ['notice', 'run', 'foo'],
+      ['notice', 'run', 'bar baz buzz'],
+    ])
     t.ok(spawk.done())
   })
 
@@ -75,7 +80,7 @@ t.test('run-script-pkg', async t => {
         },
       },
     })
-    t.strictSame(output, [])
+    t.strictSame(logs, [])
     t.ok(spawk.done())
   })
 
@@ -98,11 +103,10 @@ t.test('run-script-pkg', async t => {
       args: ['a', 'b', 'c'],
       binPaths: false,
     })
-    t.strictSame(output, [])
+    t.strictSame(logs, [])
     t.ok(spawk.done())
   })
 
-  /* eslint-disable-next-line max-len */
   await t.test('pkg has no install or preinstall script, node-gyp files present, stdio pipe', async t => {
     const testdir = t.testdir({
       'binding.gyp': 'exists',
@@ -122,7 +126,7 @@ t.test('run-script-pkg', async t => {
         scripts: {},
       },
     })
-    t.strictSame(output, [])
+    t.strictSame(logs, [])
     t.ok(spawk.done())
   })
 
@@ -146,7 +150,7 @@ t.test('run-script-pkg', async t => {
         },
       },
     })
-    t.strictSame(output, [])
+    t.strictSame(logs, [])
     t.strictSame(res, { code: 0, signal: null })
   })
 
@@ -196,7 +200,10 @@ t.test('run-script-pkg', async t => {
         },
       },
     }))
-    t.strictSame(output, [['\n> husky@1.2.3 sleep\n> sleep 1000000\n']])
+    t.strictSame(logs, [
+      ['notice', 'run', 'husky@1.2.3 sleep'],
+      ['notice', 'run', 'sleep 1000000'],
+    ])
     t.ok(spawk.done())
     if (!isWindows) {
       t.equal(signal, 'SIGFOO', 'process.kill got expected signal')
@@ -233,7 +240,10 @@ t.test('run-script-pkg', async t => {
         },
       },
     }))
-    t.strictSame(output, [['\n> husky@1.2.3 sleep\n> sleep 1000000\n']])
+    t.strictSame(logs, [
+      ['notice', 'run', 'husky@1.2.3 sleep'],
+      ['notice', 'run', 'sleep 1000000'],
+    ])
     t.ok(spawk.done())
     if (!isWindows) {
       t.equal(signal, 'SIGFOO', 'process.kill got expected signal')
@@ -269,7 +279,10 @@ t.test('run-script-pkg', async t => {
         },
       },
     }))
-    t.strictSame(output, [['\n> husky@1.2.3 sleep\n> sleep 1000000\n']])
+    t.strictSame(logs, [
+      ['notice', 'run', 'husky@1.2.3 sleep'],
+      ['notice', 'run', 'sleep 1000000'],
+    ])
     t.ok(spawk.done())
     if (!isWindows) {
       t.equal(signal, 'SIGFOO', 'process.kill got expected signal')
@@ -294,7 +307,7 @@ t.test('run-script-pkg', async t => {
         },
       },
     }))
-    t.strictSame(output, [])
+    t.strictSame(logs, [])
     t.ok(spawk.done())
   })
 })

--- a/test/validate-options.js
+++ b/test/validate-options.js
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 const t = require('tap')
 const runScript = require('..')
 


### PR DESCRIPTION
This contains two commits:

 - rename variable (this allows us to stop skipping linting for that variable
 - move banner output to a log event

fixes https://github.com/npm/statusboard/issues/1072